### PR TITLE
update terminal

### DIFF
--- a/SerialTool/src/views/terminal/qvterminal/qvterminal.h
+++ b/SerialTool/src/views/terminal/qvterminal/qvterminal.h
@@ -39,6 +39,7 @@ public slots:
 protected slots:
     void read();
     void appendString(QString str);
+    void reduceString(int position);
     void toggleCursor();
     void clearToEnd();
 

--- a/SerialTool/src/views/terminal/qvterminal/qvtline.cpp
+++ b/SerialTool/src/views/terminal/qvterminal/qvtline.cpp
@@ -20,6 +20,13 @@ void QVTLine::append(const QVTChar &c, int position)
     }
 }
 
+void QVTLine::reduce(int position)
+{
+    if (position >= 0 && position < _chars.count()) {
+        _chars.remove(position,1);
+    }
+}
+
 const QVector<QVTChar> &QVTLine::chars() const
 {
     return _chars;

--- a/SerialTool/src/views/terminal/qvterminal/qvtline.h
+++ b/SerialTool/src/views/terminal/qvterminal/qvtline.h
@@ -10,6 +10,7 @@ public:
     QVTLine();
 
     void append(const QVTChar &c, int position = -1);
+    void reduce(int position);
     void reserve(int size);
     const QVector<QVTChar> &chars() const;
     int size() const;


### PR DESCRIPTION
解决了terminal下Backspace和delete操作的输入和显示异常。
增加了ins  pgup pgdn的输入控制（不见得有用）。
即https://github.com/tumuyan/SerialTool/commit/3ec5171fc8f66dfccd23cb597498ac29a230b456

ansi转义序列关于删除字符是这么定义的：  
CSI n J ，清除屏幕的部分区域。如果n是0（或缺失），则清除从光标位置到屏幕末尾的部分。如果n是1，则清除从光标位置到屏幕开头的部分。如果n是2，则清除整个屏幕（在DOS ANSI.SYS中，光标还会向左上方移动）。如果n是3，则清除整个屏幕，并删除回滚缓存区中的所有行（这个特性是xterm添加的，其他终端应用程序也支持）。  
然而我的真机在删除字符1233456中的3时，返回的数据是这样的:"appendData=\b3456\x1B[J\b\b\b\b".    
故代码并没按照规则处理x1B[J，而是忽略了数字参数n   
这又导致了另一个问题：  
在clear命令时，返回的数据是这样的"appendData=\x1B[H\x1B[J/ # "  ，\x1B无法依照规则清空屏幕屏幕。  
为了避免出现更多问题，没有添加对\x1B[H的解析  
